### PR TITLE
Added capability to read and write carriers with anchors to shared array. Updated unit testing for new methods.

### DIFF
--- a/src/sprint_three_player/Communication.java
+++ b/src/sprint_three_player/Communication.java
@@ -320,14 +320,15 @@ public class Communication {
     }
 
     /** Add carrier ID to array of carrier ID's **/
-    public static void addCarrierID(RobotController rc) throws GameActionException {
+    public static boolean addCarrierID(RobotController rc) throws GameActionException {
         int id = rc.getID();
         for (int i = 0; i < NUM_CARRIERS; ++i) {
             if (carrierIDs[i] == 0) {
                 carrierIDs[i] = id;
-                break;
+                return true;
             }
         }
+        return false;
     }
 
     /** Get index of carrier within ID tracking array **/

--- a/src/sprint_three_player/Communication.java
+++ b/src/sprint_three_player/Communication.java
@@ -34,10 +34,12 @@ public class Communication {
     // Bit shift amount for storage.
     private static final int BIT_SHIFT = 4;
 
+    // Array to hold ID'd carriers up to number of max carriers in shared array (for tracking location).
+    private static int[] carrierIDs = new int[NUM_CARRIERS];
+
     // Counters for objects in shared array.
     private static int well_count = 0;
     private static int island_count = 0;
-    private static int carrier_count = 0;
 
     /** Read headquarter location closest to robot. **/
     public static MapLocation readHQ(RobotController rc) throws GameActionException {
@@ -313,6 +315,39 @@ public class Communication {
                 if (rc.canWriteSharedArray(i, 0)) {
                     rc.writeSharedArray(i, 0);
                 }
+            }
+        }
+    }
+
+    /** Add carrier ID to array of carrier ID's **/
+    public static void addCarrierID(RobotController rc) throws GameActionException {
+        int id = rc.getID();
+        for (int i = 0; i < NUM_CARRIERS; ++i) {
+            if (carrierIDs[i] == 0) {
+                carrierIDs[i] = id;
+                break;
+            }
+        }
+    }
+
+    /** Get index of carrier within ID tracking array **/
+    public static int getCarrierIndex(RobotController rc) throws GameActionException {
+        int id = rc.getID();
+        for (int i = 0; i < NUM_CARRIERS; ++i) {
+            if (carrierIDs[i] == id) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** Remove carrier from ID tracking array **/
+    public static void removeCarrierID(RobotController rc) throws GameActionException {
+        int id = rc.getID();
+        for (int i = 0; i < NUM_CARRIERS; ++i) {
+            if (carrierIDs[i] == id) {
+                carrierIDs[i] = 0;
+                break;
             }
         }
     }

--- a/test/sprint_three_player/CommunicationTest.java
+++ b/test/sprint_three_player/CommunicationTest.java
@@ -1027,18 +1027,50 @@ public class CommunicationTest {
         assertArrayEquals(validArray, rc.getArray());
     }
 
-    // Testing add and getting a Carrier's ID to tracking array.
+    // Testing add a Carrier's ID to tracking array can add.
     @Test
-    public void testAddAndGetCarrierID() throws GameActionException {
+    public void testCanAddCarrierID() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
-        Communication.addCarrierID(rc);
+        assertTrue(Communication.addCarrierID(rc));
+        Communication.removeCarrierID(rc);
+    }
+
+    // Testing add a Carrier's ID to tracking array cannot add.
+    @Test
+    public void testCannotAddCarrierID() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        boolean result = true;
+        for (int i = 0; i < 17; ++i) {
+            rc.setMyID(13000 + i);
+            result = Communication.addCarrierID(rc);
+        }
+        assertTrue(result);
+        rc.setMyID(15000);
+        assertFalse(Communication.addCarrierID(rc));
+        for (int i = 0; i < 17; ++i) {
+            rc.setMyID(13000 + i);
+            Communication.removeCarrierID(rc);
+        }
+    }
+
+    // Testing getting a Carrier's index from tracking array.
+    @Test
+    public void testGetCarrierIndex() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        assertEquals(-1, Communication.getCarrierIndex(rc));
+        boolean result = Communication.addCarrierID(rc);
+        assertTrue(result);
         assertEquals(0, Communication.getCarrierIndex(rc));
+        Communication.removeCarrierID(rc);
     }
 
     // Testing removing and not getting a Carrier's ID to tracking array.
     @Test
     public void testRemoveAndNotGetCarrierID() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
+        boolean result = Communication.addCarrierID(rc);
+        assertTrue(result);
+        assertEquals(0, Communication.getCarrierIndex(rc));
         Communication.removeCarrierID(rc);
         assertEquals(-1, Communication.getCarrierIndex(rc));
     }

--- a/test/sprint_three_player/CommunicationTest.java
+++ b/test/sprint_three_player/CommunicationTest.java
@@ -1026,19 +1026,36 @@ public class CommunicationTest {
         Communication.updateCarriers(rc, new MapLocation(1, 1));
         assertArrayEquals(validArray, rc.getArray());
     }
+
+    // Testing add and getting a Carrier's ID to tracking array.
+    @Test
+    public void testAddAndGetCarrierID() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        Communication.addCarrierID(rc);
+        assertEquals(0, Communication.getCarrierIndex(rc));
+    }
+
+    // Testing removing and not getting a Carrier's ID to tracking array.
+    @Test
+    public void testRemoveAndNotGetCarrierID() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        Communication.removeCarrierID(rc);
+        assertEquals(-1, Communication.getCarrierIndex(rc));
+    }
 }
 
 /**
  * Implements a simple mock RobotController for testing. Has to implement all methods, but the only affected methods
- * are getMapWidth, getMapHeight, getLocation, getTeam, senseNearbyWells, senseNearbyIslands, senseTeamOccupyingIsland, and
- * senseNearbyIslandLocations. New methods for testing include setSharedArray, setCanWriteResult, setLocation, getArray,
- * setWells, setCurrentIslands, setCurrentTeam, setCurrentIslandLocations, setTeam, and reset.
+ * are getMapWidth, getMapHeight, getID, getLocation, getTeam, senseNearbyWells, senseNearbyIslands, senseTeamOccupyingIsland,
+ * and senseNearbyIslandLocations. New methods for testing include setSharedArray, setCanWriteResult, setLocation, getArray,
+ * setWells, setCurrentIslands, setCurrentTeam, setCurrentIslandLocations, setTeam, reset, and setMyID.
  **/
 class CommunicationRobotController implements RobotController {
     MapLocation currentLocation = new MapLocation(0, 0);
     WellInfo[] currentWells = new WellInfo[] {};
     Team myTeam = Team.A;
     int[] currentIslands = new int[] {0, 1, 2};
+    int myID = 15421;
     Team[] currentTeam = new Team[] {Team.NEUTRAL, Team.A, Team.B};
     MapLocation[] islandLocations = new MapLocation[] {new MapLocation(1, 1), new MapLocation(1, 2), new MapLocation(2, 2)};
     boolean canWriteResult = true;
@@ -1098,11 +1115,19 @@ class CommunicationRobotController implements RobotController {
         };
     }
 
+    public void setMyID(int id) {
+        myID = id;
+    }
+
     @Override
     public Team getTeam() {
         return myTeam;
     }
 
+    @Override
+    public int getID() {
+        return myID;
+    }
 
     @Override
     public int[] senseNearbyIslands() {
@@ -1177,11 +1202,6 @@ class CommunicationRobotController implements RobotController {
 
     @Override
     public int getRobotCount() {
-        return 0;
-    }
-
-    @Override
-    public int getID() {
         return 0;
     }
 

--- a/test/sprint_three_player/CommunicationTest.java
+++ b/test/sprint_three_player/CommunicationTest.java
@@ -836,9 +836,9 @@ public class CommunicationTest {
         assertEquals(new MapLocation(1, 1), closestCarrier);
     }
 
-    // Testing writing a Carrier that is null.
+    // Testing initializing a Carrier that is null.
     @Test
-    public void testWriteNullCarrier() throws GameActionException {
+    public void testInitializeNullCarrier() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
         rc.setLocation(null);
         int[] validArray = new int[] {
@@ -852,13 +852,13 @@ public class CommunicationTest {
                 0, 0, 0, 0, 0, 0, 0, 0
         };
 
-        Communication.writeCarrier(rc);
+        Communication.initializeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
     }
 
-    // Testing writing a Carrier to an empty shared array when it can write.
+    // Testing initializing a Carrier to an empty shared array when it can write.
     @Test
-    public void testWriteCarrierToEmptyArrayCanWrite() throws GameActionException {
+    public void testInitializeCarrierToEmptyArrayCanWrite() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
         rc.setLocation(new MapLocation(1, 1));
         int[] validArray = new int[] {
@@ -872,13 +872,14 @@ public class CommunicationTest {
                 0, 0, 0, 0, 0, 0, 0, 0
         };
 
-        Communication.writeCarrier(rc);
+        Communication.initializeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
     }
 
-    // Testing writing a Carrier to an empty shared array when it cannot write.
+    // Testing initializing a Carrier to an empty shared array when it cannot write.
     @Test
-    public void testWriteCarrierToEmptyArrayCannotWrite() throws GameActionException {
+    public void testInitializeCarrierToEmptyArrayCannotWrite() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
         rc.setLocation(new MapLocation(1, 1));
         int[] validArray = new int[] {
@@ -893,15 +894,19 @@ public class CommunicationTest {
         };
 
         rc.setCanWriteResult(false);
-        Communication.writeCarrier(rc);
+        Communication.initializeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
     }
 
-    // Testing writing a Carrier to a shared array with one Carrier.
+    // Testing initializing a Carrier to a shared array with one Carrier.
     @Test
-    public void testWriteCarrierWithOneCarrierInArray() throws GameActionException {
+    public void testInitializeCarrierWithOneCarrierInArray() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(new MapLocation(2, 2));
+        rc.setMyID(11000);
+        Communication.addCarrierID(rc);
         rc.setLocation(new MapLocation(1, 1));
+        rc.setMyID(12000);
         int[] existingArray = new int[] {
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
@@ -925,15 +930,26 @@ public class CommunicationTest {
 
         rc.setSharedArray(existingArray);
 
-        Communication.writeCarrier(rc);
+        Communication.initializeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
     }
 
-    // Testing writing a Carrier to a shared array with multiple Carrier.
+    // Testing initializing a Carrier to a shared array with multiple Carrier.
     @Test
-    public void testWriteCarrierWithMultipleCarrierInArray() throws GameActionException {
+    public void testInitializeCarrierWithMultipleCarrierInArray() throws GameActionException {
         CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(new MapLocation(2, 2));
+        rc.setMyID(11000);
+        Communication.addCarrierID(rc);
+        rc.setLocation(new MapLocation(1, 2));
+        rc.setMyID(12000);
+        Communication.addCarrierID(rc);
+        rc.setLocation(new MapLocation(2, 1));
+        rc.setMyID(13000);
+        Communication.addCarrierID(rc);
         rc.setLocation(new MapLocation(1, 1));
+        rc.setMyID(14000);
         int[] existingArray = new int[] {
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
@@ -956,13 +972,141 @@ public class CommunicationTest {
         };
 
         rc.setSharedArray(existingArray);
-        Communication.writeCarrier(rc);
+        Communication.initializeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
+    }
+
+    // Testing initializing a Carrier to a shared array that is full.
+    @Test
+    public void testInitializeCarrierFull() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        for (int i = 0; i < 17; ++i) {
+            rc.setMyID(14000 + i);
+            Communication.addCarrierID(rc);
+        }
+        rc.setMyID(16000);
+        rc.setLocation(new MapLocation(1, 1));
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 112,
+                128, 23, 24, 25, 26, 48, 94, 99,
+                54, 30, 1, 2, 1000, 939, 324, 0
+        };
+        rc.setSharedArray(validArray);
+        Communication.initializeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
+    }
+
+    // Testing updating a Carrier that is null.
+    @Test
+    public void testUpdateNullCarrier() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(null);
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        Communication.updateCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
     }
 
-    // Testing updating carriers when carrier does not exist.
+    // Testing updating a Carrier that does not exist.
     @Test
-    public void testUpdateCarriersDoesNotExist() throws GameActionException{
+    public void testUpdateCarrierDoesNotExist() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setMyID(11000);
+        Communication.addCarrierID(rc);
+        rc.setMyID(14000);
+        rc.setLocation(new MapLocation(1, 1));
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(validArray);
+        Communication.updateCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
+    }
+
+    // Testing updating a Carrier cannot write.
+    @Test
+    public void testUpdateCarrierCannotWrite() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setMyID(11000);
+        Communication.addCarrierID(rc);
+        rc.setLocation(new MapLocation(1, 1));
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(validArray);
+        rc.setCanWriteResult(false);
+        Communication.updateCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
+    }
+
+    // Testing updating a Carrier can write.
+    @Test
+    public void testUpdateCarrierCanWrite() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setMyID(11000);
+        Communication.addCarrierID(rc);
+        rc.setLocation(new MapLocation(1, 1));
+        int[] existingArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 80, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(existingArray);
+        Communication.updateCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+        Communication.removeAllCarrierIDs();
+    }
+
+    // Testing removing carriers when carrier does not exist.
+    @Test
+    public void testRemoveCarriersDoesNotExist() throws GameActionException{
         CommunicationRobotController rc = new CommunicationRobotController();
         int[] validArray = new int[] {
                 0, 0, 0, 0, 0, 0, 0, 0,
@@ -974,13 +1118,13 @@ public class CommunicationTest {
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0
         };
-        Communication.updateCarriers(rc, new MapLocation(1, 1));
+        Communication.removeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
     }
 
-    // Testing updating carriers when robot cannot write.
+    // Testing removing carriers when robot cannot write.
     @Test
-    public void testUpdateCarriersCannotWrite() throws GameActionException{
+    public void testRemoveCarriersCannotWrite() throws GameActionException{
         CommunicationRobotController rc = new CommunicationRobotController();
         int[] validArray = new int[] {
                 0, 0, 0, 0, 0, 0, 0, 0,
@@ -994,14 +1138,15 @@ public class CommunicationTest {
         };
         rc.setSharedArray(validArray);
         rc.setCanWriteResult(false);
-        Communication.updateCarriers(rc, new MapLocation(1, 1));
+        Communication.removeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
     }
 
-    // Testing updating carriers when robot can write.
+    // Testing remove carriers when robot can write.
     @Test
     public void testUpdateCarriersCanWrite() throws GameActionException{
         CommunicationRobotController rc = new CommunicationRobotController();
+        Communication.addCarrierID(rc);
         int[] initialArray = new int[] {
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1023,7 +1168,7 @@ public class CommunicationTest {
                 0, 0, 0, 0, 0, 0, 0, 0
         };
         rc.setSharedArray(initialArray);
-        Communication.updateCarriers(rc, new MapLocation(1, 1));
+        Communication.removeCarrier(rc);
         assertArrayEquals(validArray, rc.getArray());
     }
 
@@ -1073,6 +1218,25 @@ public class CommunicationTest {
         assertEquals(0, Communication.getCarrierIndex(rc));
         Communication.removeCarrierID(rc);
         assertEquals(-1, Communication.getCarrierIndex(rc));
+    }
+
+    // Testing removing all carriers from ID tracking array.
+    @Test
+    public void testRemoveAllCarrierIDs() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        for (int i = 0; i < 17; ++i) {
+            rc.setMyID(14000 + i);
+            assertTrue(Communication.addCarrierID(rc));
+        }
+        for (int i = 0; i < 17; ++i) {
+            rc.setMyID(14000 + i);
+            assertNotEquals(-1, Communication.getCarrierIndex(rc));
+        }
+        Communication.removeAllCarrierIDs();
+        for (int i = 0; i < 17; ++i) {
+            rc.setMyID(14000 + i);
+            assertEquals(-1, Communication.getCarrierIndex(rc));
+        }
     }
 }
 

--- a/test/sprint_three_player/CommunicationTest.java
+++ b/test/sprint_three_player/CommunicationTest.java
@@ -658,9 +658,9 @@ public class CommunicationTest {
                 1, 1, 1, 1, 1, 1, 1, 1,
                 1, 1, 1, 1, 1, 1, 1, 1,
                 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 2, 1,
                 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1, 1, 1, 1
+                1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 2
         };
         rc.setSharedArray(initialArray);
         int priorityResult = Communication.readPriority(rc);
@@ -696,9 +696,9 @@ public class CommunicationTest {
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 1, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 1
         };
         int[] validArray = new int[] {
                 0, 0, 0, 0, 0, 0, 0, 0,
@@ -706,9 +706,9 @@ public class CommunicationTest {
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 2, 0,
                 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 2
         };
         rc.setSharedArray(initialArray);
         Communication.writePriority(rc, 2);
@@ -787,6 +787,244 @@ public class CommunicationTest {
     public void testReadOpponentOccupiedIsland() {
         CommunicationRobotController rc = new CommunicationRobotController();
         assertEquals(2, Communication.islandStateNum(rc.getTeam(), Team.B));
+    }
+
+    // Testing reading a Carrier from an empty shared array.
+    @Test
+    public void testReadCarrierWithEmptySharedArray() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        MapLocation closestCarrier = Communication.readCarrier(rc);
+        // Assert that location is null.
+        assertNull(closestCarrier);
+    }
+
+    // Testing reading the closest Carrier from a shared array with one Carrier.
+    @Test
+    public void testReadCarrierWithOneCarrier() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        int[] oneCarrierInArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(oneCarrierInArray);
+        MapLocation carrierLocation = Communication.readCarrier(rc);
+        assertEquals(new MapLocation(2, 2), carrierLocation);
+    }
+
+    // Testing reading the closest Carrier from a shared array with multiple Carrier's.
+    @Test
+    public void testReadCarrierWithMultipleCarrier() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        int[] multiCarrierInArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 112, 80,
+                128, 144, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(multiCarrierInArray);
+        MapLocation closestCarrier = Communication.readCarrier(rc);
+        assertEquals(new MapLocation(1, 1), closestCarrier);
+    }
+
+    // Testing writing a Carrier that is null.
+    @Test
+    public void testWriteNullCarrier() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(null);
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        Communication.writeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing writing a Carrier to an empty shared array when it can write.
+    @Test
+    public void testWriteCarrierToEmptyArrayCanWrite() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(new MapLocation(1, 1));
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 80, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        Communication.writeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing writing a Carrier to an empty shared array when it cannot write.
+    @Test
+    public void testWriteCarrierToEmptyArrayCannotWrite() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(new MapLocation(1, 1));
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        rc.setCanWriteResult(false);
+        Communication.writeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing writing a Carrier to a shared array with one Carrier.
+    @Test
+    public void testWriteCarrierWithOneCarrierInArray() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(new MapLocation(1, 1));
+        int[] existingArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 80,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        rc.setSharedArray(existingArray);
+
+        Communication.writeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing writing a Carrier to a shared array with multiple Carrier.
+    @Test
+    public void testWriteCarrierWithMultipleCarrierInArray() throws GameActionException {
+        CommunicationRobotController rc = new CommunicationRobotController();
+        rc.setLocation(new MapLocation(1, 1));
+        int[] existingArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 112,
+                128, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 144, 112,
+                128, 80, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+
+        rc.setSharedArray(existingArray);
+        Communication.writeCarrier(rc);
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing updating carriers when carrier does not exist.
+    @Test
+    public void testUpdateCarriersDoesNotExist() throws GameActionException{
+        CommunicationRobotController rc = new CommunicationRobotController();
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        Communication.updateCarriers(rc, new MapLocation(1, 1));
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing updating carriers when robot cannot write.
+    @Test
+    public void testUpdateCarriersCannotWrite() throws GameActionException{
+        CommunicationRobotController rc = new CommunicationRobotController();
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 80, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(validArray);
+        rc.setCanWriteResult(false);
+        Communication.updateCarriers(rc, new MapLocation(1, 1));
+        assertArrayEquals(validArray, rc.getArray());
+    }
+
+    // Testing updating carriers when robot can write.
+    @Test
+    public void testUpdateCarriersCanWrite() throws GameActionException{
+        CommunicationRobotController rc = new CommunicationRobotController();
+        int[] initialArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 80, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        int[] validArray = new int[] {
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+        };
+        rc.setSharedArray(initialArray);
+        Communication.updateCarriers(rc, new MapLocation(1, 1));
+        assertArrayEquals(validArray, rc.getArray());
     }
 }
 


### PR DESCRIPTION
If a Carrier is carrying an anchor, it's duties are to:
- initializeCarrier: when Carrier first picks up an anchor, call this to place Carrier's location in the shared array
- updateCarrier: while the Carrier carriers an anchor, call this to update it's location in the shared array at every round
- removeCarrier: when the Carrier plants an anchor on an island, call this to remove the Carrier from the shared array

For Launchers wanting to follow a Carrier with an anchor:
- readCarrier: returns the closest Carrier with an anchor